### PR TITLE
Support test command w/ tests_require & test_suite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         'gevent',
         'requests'
     ],
+    tests_require = ['nose'],
+    test_suite = 'nose.collector',
     py_modules=['grequests'],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Leverage tests_require and test_suite to enable running the nose test collector via the standard setup.py test command