### PR TITLE
Differentiate HTTP errors like 404 from connection errors.

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -117,7 +117,7 @@ def map(requests, stream=False, size=None, exception_handler=None):
     ret = []
 
     for request in requests:
-        if request.response:
+        if request.response is not None:
             ret.append(request.response)
         elif exception_handler:
             exception_handler(request, request.exception)
@@ -141,7 +141,7 @@ def imap(requests, stream=False, size=2, exception_handler=None):
         return r.send(stream=stream)
 
     for request in pool.imap_unordered(send, requests):
-        if request.response:
+        if request.response is not None:
             yield request.response
         elif exception_handler:
             exception_handler(request, request.exception)


### PR DESCRIPTION
With the previous code, a 404 or other HTTP error would result in:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "dload.py", line 16, in download_urls
    exception_handler=exception_handler):
  File "/app/lib/python2.7/site-packages/grequests.py", line 148, in imap
    exception_handler(request, request.exception)
AttributeError: 'AsyncRequest' object has no attribute 'exception'

This is because gevent didn't store the exception in the request because an HTTP error does not cause an exception. We're in this case though because request.response evaluates to False if the Response was an HTTP error.

Also, can we get a release soon? Version 0.20 is kinda lacking without connection error handling. Thanks.