### PR TITLE
exception handling fix: edge case where request.response evaluates to false

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Usage is simple::
         'http://python-tablib.org',
         'http://httpbin.org',
         'http://python-requests.org',
+        'http://fakedomain/',
         'http://kennethreitz.com'
     ]
 
@@ -27,7 +28,7 @@ Create a set of unsent Requests::
 Send them all at the same time::
 
     >>> grequests.map(rs)
-    [<Response [200]>, <Response [200]>, <Response [200]>, <Response [200]>, <Response [200]>]
+    [<Response [200]>, <Response [200]>, <Response [200]>, <Response [200]>, None, <Response [200]>]
 
 Optionally, in the event of a timeout or any other exception during the connection of
 the request, you can add an exception handler that will be called with the request and
@@ -35,7 +36,6 @@ exception inside the main thread::
 
     >>> def exception_handler(request, exception):
     ...    print "Request failed"
-    ...    return False
 
     >>> reqs = [
     ...    grequests.get('http://httpbin.org/delay/1', timeout=0.001),
@@ -44,7 +44,7 @@ exception inside the main thread::
     >>> grequests.map(reqs, exception_handler=exception_handler)
     Request failed
     Request failed
-    [<Response [500]>]
+    [None, None, <Response [500]>]
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ exception inside the main thread::
 
     >>> def exception_handler(request, exception):
     ...    print "Request failed"
+    ...    return False
 
     >>> reqs = [
     ...    grequests.get('http://httpbin.org/delay/1', timeout=0.001),

--- a/grequests.py
+++ b/grequests.py
@@ -9,7 +9,7 @@ by gevent. All API methods return a ``Request`` instance (as opposed to
 ``Response``). A list of requests can be sent with ``map()``.
 """
 from functools import partial
-
+import traceback
 try:
     import gevent
     from gevent import monkey as curious_george
@@ -72,6 +72,7 @@ class AsyncRequest(object):
                                                 self.url, **merged_kwargs)
         except Exception as e:
             self.exception = e
+            self.traceback = traceback.format_exc()
         return self
 
 

--- a/grequests.py
+++ b/grequests.py
@@ -121,7 +121,11 @@ def map(requests, stream=False, size=None, exception_handler=None):
         if request.response is not None:
             ret.append(request.response)
         elif exception_handler:
-            exception_handler(request, request.exception)
+            rv = exception_handler(request, request.exception)
+            if rv is not False:
+                ret.append(rv)
+        else:
+            ret.append(None)
 
     return ret
 

--- a/grequests.py
+++ b/grequests.py
@@ -117,10 +117,10 @@ def map(requests, stream=False, size=None, exception_handler=None):
     ret = []
 
     for request in requests:
-        if hasattr(request, 'exception') and exception_handler:
-            exception_handler(request, request.exception)
-        else:
+        if request.response is not None:
             ret.append(request.response)
+        else:
+            exception_handler(request, request.exception)
 
     return ret
 
@@ -141,10 +141,9 @@ def imap(requests, stream=False, size=2, exception_handler=None):
         return r.send(stream=stream)
 
     for request in pool.imap_unordered(send, requests):
-        if hasattr(request, 'exception') and exception_handler:
-            exception_handler(request, request.exception)
-        else:
+        if request.response is not None:
             yield request.response
-
+        else:
+            exception_handler(request, request.exception)
 
     pool.join()

--- a/grequests.py
+++ b/grequests.py
@@ -120,7 +120,7 @@ def map(requests, stream=False, size=None, exception_handler=None):
     for request in requests:
         if request.response is not None:
             ret.append(request.response)
-        else:
+        elif exception_handler:
             exception_handler(request, request.exception)
 
     return ret
@@ -144,7 +144,7 @@ def imap(requests, stream=False, size=2, exception_handler=None):
     for request in pool.imap_unordered(send, requests):
         if request.response is not None:
             yield request.response
-        else:
+        elif exception_handler:
             exception_handler(request, request.exception)
 
     pool.join()

--- a/grequests.py
+++ b/grequests.py
@@ -121,9 +121,7 @@ def map(requests, stream=False, size=None, exception_handler=None):
         if request.response is not None:
             ret.append(request.response)
         elif exception_handler:
-            rv = exception_handler(request, request.exception)
-            if rv is not False:
-                ret.append(rv)
+            ret.append(exception_handler(request, request.exception))
         else:
             ret.append(None)
 

--- a/grequests.py
+++ b/grequests.py
@@ -117,10 +117,10 @@ def map(requests, stream=False, size=None, exception_handler=None):
     ret = []
 
     for request in requests:
-        if request.response:
-            ret.append(request.response)
-        elif exception_handler:
+        if hasattr(request, 'exception') and exception_handler:
             exception_handler(request, request.exception)
+        else:
+            ret.append(request.response)
 
     return ret
 
@@ -141,9 +141,10 @@ def imap(requests, stream=False, size=2, exception_handler=None):
         return r.send(stream=stream)
 
     for request in pool.imap_unordered(send, requests):
-        if request.response:
-            yield request.response
-        elif exception_handler:
+        if hasattr(request, 'exception') and exception_handler:
             exception_handler(request, request.exception)
+        else:
+            yield request.response
+
 
     pool.join()

--- a/tests.py
+++ b/tests.py
@@ -202,6 +202,18 @@ class GrequestsCase(unittest.TestCase):
             out.append(r)
         self.assertEquals(out, [])
 
+    def test_imap_timeout_exception_handler_returns_value(self):
+        """
+        ensure behaviour for a handler that returns a value
+        """
+        def exception_handler(request, exception):
+            return request
+        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
+        out = []
+        for r in grequests.imap(reqs, exception_handler=exception_handler):
+            out.append(r)
+        self.assertEquals(out, [])
+
     def test_map_timeout_exception(self):
         class ExceptionHandler:
             def __init__(self):

--- a/tests.py
+++ b/tests.py
@@ -30,6 +30,7 @@ import time
 import unittest
 
 import requests
+from requests.exceptions import Timeout
 import grequests
 
 HTTPBIN_URL = os.environ.get('HTTPBIN_URL', 'http://httpbin.org/')
@@ -123,6 +124,7 @@ class GrequestsCase(unittest.TestCase):
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs)
         self.assertEqual(len(responses), 2)
+        self.assertIsNone(responses[0])
 
     def test_map_timeout_exception_handler_returns_false(self):
         def exception_handler(request, exception):
@@ -137,6 +139,7 @@ class GrequestsCase(unittest.TestCase):
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs, exception_handler=exception_handler)
         self.assertEqual(len(responses), 2)
+        self.assertIsNone(responses[0])
 
     def test_map_timeout_exception_handler_returns_exception(self):
         def exception_handler(request, exception):
@@ -144,6 +147,7 @@ class GrequestsCase(unittest.TestCase):
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs, exception_handler=exception_handler)
         self.assertEqual(len(responses), 2)
+        self.assertIsInstance(responses[0], Timeout)
 
     def test_imap_timeout(self):
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]

--- a/tests.py
+++ b/tests.py
@@ -153,6 +153,12 @@ class GrequestsCase(unittest.TestCase):
         list(grequests.imap(reqs, exception_handler=eh.callback))
         self.assertEqual(eh.counter, 1)
 
+    def test_map_inputs_match_outputs_with_exception(self):
+        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
+        res = grequests.map(reqs)
+        self.assertEquals(len(reqs), len(res))
+        self.assertEquals(res, [None])
+
     def get(self, url, **kwargs):
         return grequests.map([grequests.get(url, **kwargs)])[0]
 

--- a/tests.py
+++ b/tests.py
@@ -121,38 +121,86 @@ class GrequestsCase(unittest.TestCase):
         self.assertLess((time.time() - t), n)
 
     def test_map_timeout_no_exception_handler(self):
+        """
+        compliance with existing 0.2.0 behaviour
+        """
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs)
-        self.assertEqual(len(responses), 2)
         self.assertIsNone(responses[0])
+        self.assertTrue(responses[1].ok)
+        self.assertEqual(len(responses), 2)
 
     def test_map_timeout_exception_handler_returns_false(self):
+        """
+        if you don't want your exceptions to show up in the map result
+        """
         def exception_handler(request, exception):
             return False
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs, exception_handler=exception_handler)
+        self.assertTrue(responses[0].ok)
         self.assertEqual(len(responses), 1)
 
     def test_map_timeout_exception_handler_no_return(self):
+        """
+        ensure default behaviour for a handler that returns None
+        """
         def exception_handler(request, exception):
             pass
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs, exception_handler=exception_handler)
-        self.assertEqual(len(responses), 2)
         self.assertIsNone(responses[0])
+        self.assertTrue(responses[1].ok)
+        self.assertEqual(len(responses), 2)
 
     def test_map_timeout_exception_handler_returns_exception(self):
+        """
+        ensure returned value from exception handler is stuffed in the map result
+        """
         def exception_handler(request, exception):
             return exception
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
         responses = grequests.map(reqs, exception_handler=exception_handler)
-        self.assertEqual(len(responses), 2)
         self.assertIsInstance(responses[0], Timeout)
+        self.assertTrue(responses[1].ok)
+        self.assertEqual(len(responses), 2)
 
-    def test_imap_timeout(self):
-        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001), grequests.get(httpbin('/'))]
-        responses = list(grequests.imap(reqs))
-        self.assertEqual(len(responses), 1)
+    def test_imap_timeout_no_exception_handler(self):
+        """
+        compliance with existing 0.2.0 behaviour
+        """
+        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
+        out = []
+        try:
+            for r in grequests.imap(reqs):
+                out.append(r)
+        except Timeout:
+            pass
+        self.assertEquals(out, [])
+
+    def test_imap_timeout_exception_handler_no_return(self):
+        """
+        ensure imap-default behaviour for a handler that returns None
+        """
+        def exception_handler(request, exception):
+            pass
+        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
+        out = []
+        for r in grequests.imap(reqs, exception_handler=exception_handler):
+            out.append(r)
+        self.assertEquals(out, [])
+
+    def test_imap_timeout_exception_handler_returns_false(self):
+        """
+        ensure map-compatible behaviour for a handler that returns False
+        """
+        def exception_handler(request, exception):
+            return False
+        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
+        out = []
+        for r in grequests.imap(reqs, exception_handler=exception_handler):
+            out.append(r)
+        self.assertEquals(out, [])
 
     def test_map_timeout_exception(self):
         class ExceptionHandler:


### PR DESCRIPTION
fix cases where request.response would evaluate to false, and we'd erroneously enter the exception handling code when there was no exception