### PR TITLE
Threat 404 as a normal response

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -117,7 +117,7 @@ def map(requests, stream=False, size=None, exception_handler=None):
     ret = []
 
     for request in requests:
-        if request.response:
+        if request.response is not None:
             ret.append(request.response)
         elif exception_handler:
             exception_handler(request, request.exception)
@@ -141,7 +141,7 @@ def imap(requests, stream=False, size=2, exception_handler=None):
         return r.send(stream=stream)
 
     for request in pool.imap_unordered(send, requests):
-        if request.response:
+        if request.response is not None:
             yield request.response
         elif exception_handler:
             exception_handler(request, request.exception)

--- a/tests.py
+++ b/tests.py
@@ -156,6 +156,10 @@ class GrequestsCase(unittest.TestCase):
     def get(self, url, **kwargs):
         return grequests.map([grequests.get(url, **kwargs)])[0]
 
+    def test_404_is_normal_response(self):
+        reqs = [grequests.get(httpbin('status/404'))]
+        responses = list(grequests.imap(reqs))
+        self.assertEqual(len(responses), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
With a 404, [request.response](https://github.com/kennethreitz/grequests/blob/5d12c6642c5d11cb46cb6141cd87415c88de878c/grequests.py#L144) is `False`, even though there is response object. This fails if an `exception_handler` was given, as there the `request` object has no `exception` attribute. 

On a side note: this module seems stale. Has everybody moved to asyncio for this type of work? It's a pity, because I very much like the simplicity of the requests code. 