### PR TITLE
Updated grequests.py to set meta data for retry scenario.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ grequests.egg-info/
 *.py[cx]
 *.swp
 env/
+
+.idea/*


### PR DESCRIPTION
At times when the fatal request failures/aborts. The callback passed into  grequests.get() does not get called.