### PR TITLE
Created empty response when request throws Exception

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -21,6 +21,7 @@ except ImportError:
 curious_george.patch_all(thread=False, select=False)
 
 from requests import Session
+from requests import Response
 
 
 __all__ = (
@@ -73,6 +74,7 @@ class AsyncRequest(object):
         except Exception as e:
             self.exception = e
             self.traceback = traceback.format_exc()
+            self.response = Response()
         return self
 
 

--- a/grequests.py
+++ b/grequests.py
@@ -121,7 +121,7 @@ def map(requests, stream=False, size=None, exception_handler=None, gtimeout=None
     ret = []
 
     for request in requests:
-        if request.response is not None:
+        if request.response.status_code is not None:
             ret.append(request.response)
         elif exception_handler and hasattr(request, 'exception'):
             ret.append(exception_handler(request, request.exception))
@@ -147,7 +147,7 @@ def imap(requests, stream=False, size=2, exception_handler=None):
         return r.send(stream=stream)
 
     for request in pool.imap_unordered(send, requests):
-        if request.response is not None:
+        if request.response.status_code is not None:
             yield request.response
         elif exception_handler:
             exception_handler(request, request.exception)


### PR DESCRIPTION
Whenever an `Exception` is thrown by setting the `self.response` variable to an empty `Response` object allows anyone to easily mock the response information.

Where is this PR coming from:

I wanted to create an `exception_handler` that returns an response object with `status_code` set to 404 without having to import requests along side grequests.