### PR TITLE
imap behavior more consistent with map behavior

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Development Lead
 Patches and Suggestions
 ```````````````````````
 - Kracekumar <me@kracekumar.com>
+- Spencer Young <spencer.young@spyoung.com>

--- a/grequests.py
+++ b/grequests.py
@@ -148,6 +148,8 @@ def imap(requests, stream=False, size=2, exception_handler=None):
         if request.response is not None:
             yield request.response
         elif exception_handler:
-            exception_handler(request, request.exception)
+            ex_result = exception_handler(request, request.exception)
+            if ex_result is not None:
+                yield ex_result
 
     pool.join()

--- a/tests.py
+++ b/tests.py
@@ -179,29 +179,18 @@ class GrequestsCase(unittest.TestCase):
             out.append(r)
         self.assertEquals(out, [])
 
-    def test_imap_timeout_exception_handler_returns_false(self):
-        """
-        ensure map-compatible behaviour for a handler that returns False
-        """
-        def exception_handler(request, exception):
-            return False
-        reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
-        out = []
-        for r in grequests.imap(reqs, exception_handler=exception_handler):
-            out.append(r)
-        self.assertEquals(out, [])
 
     def test_imap_timeout_exception_handler_returns_value(self):
         """
         ensure behaviour for a handler that returns a value
         """
         def exception_handler(request, exception):
-            return request
+            return 'a value'
         reqs = [grequests.get(httpbin('delay/1'), timeout=0.001)]
         out = []
         for r in grequests.imap(reqs, exception_handler=exception_handler):
             out.append(r)
-        self.assertEquals(out, [])
+        self.assertEquals(out, ['a value'])
 
     def test_map_timeout_exception(self):
         class ExceptionHandler:


### PR DESCRIPTION
Changes the behavior of `imap` to be more consistent with `map`. Specifically, this PR gives `imap` the behavior that was given to `map` in #58. Addresses #111 and provides a solution for the motive behind #113 but does not force or limit what can be returned; it puts this choice in hands of users.

One test was changed and another was removed to reflect this change.

One other difference in behavior (not addressed here) is that `imap` won't return `None` like `map` does. Because `imap` is unordered, including `None` is not as useful in my view... It may be a good idea to do, but is not addressed here.