### PR TITLE
when use the GET method, should return the real url

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -70,6 +70,7 @@ class AsyncRequest(object):
         try:
             self.response = self.session.request(self.method,
                                                 self.url, **merged_kwargs)
+            self.url = self.response.url
         except Exception as e:
             self.exception = e
             self.traceback = traceback.format_exc()


### PR DESCRIPTION
like below:
```
a_tt = grequests.get('https://www.geektop.net', params={'1': 123})
```
when  I call send(), the `a_tt.url`  should return `https://www.geektop.net/?1=123`, rather than `https://www.geektop.net`
